### PR TITLE
Adjust API base URL resolution in login page

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -20,6 +20,10 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## API configuration
+
+The login page communicates with the backend through the `/api/login/` endpoint. When the app runs on `localhost`, it falls back to `http://localhost:8000` if `NEXT_PUBLIC_API_URL` is not defined. In any other environment you should configure `NEXT_PUBLIC_API_URL` with the public URL of your backend or provide a reverse proxy that exposes `/api/login/` alongside the frontend.
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:


### PR DESCRIPTION
## Summary
- compute the login API base URL at runtime using the environment variable, localhost fallback or window origin
- update the login request to reuse the normalized base URL
- document the required API configuration for non-localhost deployments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d15d4837b08326aeaa57e5f5826baf