### PR TITLE
Add categories summary page with carousel

### DIFF
--- a/frontend/src/app/categorias/interaction.ts
+++ b/frontend/src/app/categorias/interaction.ts
@@ -1,0 +1,352 @@
+type InventoryItem = {
+  id: number;
+  recurso: string;
+  categoria: string;
+  cantidad: number;
+  precio: number;
+  foto: string;
+  info: string;
+};
+
+type CleanupFn = () => void;
+
+type CategorySummary = {
+  name: string;
+  resourceCount: number;
+  totalQuantity: number;
+  totalValue: number;
+  topResource?: string;
+};
+
+type CarouselControl = {
+  cleanup: CleanupFn;
+  refresh: () => void;
+};
+
+const INVENTORY_KEY = "inventarioData";
+const CATS_KEY = "categoriasInventario";
+
+export function initializeCategoriesPage(): CleanupFn {
+  if (typeof document === "undefined") {
+    return () => {};
+  }
+
+  const cleanupFns: CleanupFn[] = [];
+  const carouselControls = Array.from(
+    document.querySelectorAll<HTMLElement>(".category-carousel")
+  ).map(setupCarousel);
+
+  cleanupFns.push(
+    ...carouselControls.map((control) => control.cleanup),
+    setupThemeToggle(),
+    setupStorageSync(() => renderCategories(carouselControls)),
+    setupFocusSync(() => renderCategories(carouselControls))
+  );
+
+  renderCategories(carouselControls);
+
+  return () => {
+    cleanupFns.forEach((fn) => fn());
+  };
+}
+
+function setupThemeToggle(): CleanupFn {
+  const toggle = document.getElementById("themeSwitch") as HTMLInputElement | null;
+  const handler = () => updateTheme(Boolean(toggle?.checked));
+  toggle?.addEventListener("change", handler);
+  applyStoredTheme();
+  return () => {
+    toggle?.removeEventListener("change", handler);
+  };
+}
+
+function setupStorageSync(refresh: () => void): CleanupFn {
+  const handler = (event: StorageEvent) => {
+    if (!event.key || [INVENTORY_KEY, CATS_KEY, "theme"].includes(event.key)) {
+      refresh();
+      if (!event.key || event.key === "theme") {
+        applyStoredTheme();
+      }
+    }
+  };
+  window.addEventListener("storage", handler);
+  return () => window.removeEventListener("storage", handler);
+}
+
+function setupFocusSync(refresh: () => void): CleanupFn {
+  const handler = () => refresh();
+  window.addEventListener("focus", handler);
+  return () => window.removeEventListener("focus", handler);
+}
+
+function renderCategories(controls: CarouselControl[]) {
+  const inventory = loadJSON<InventoryItem[]>(INVENTORY_KEY, []);
+  const storedCategories = loadJSON<string[]>(CATS_KEY, []);
+  const categories = buildCategorySummaries(inventory, storedCategories);
+  persistCategoryNames(categories.map((category) => category.name));
+
+  const topRow = categories.slice(0, Math.ceil(categories.length / 2));
+  const bottomRow = categories.slice(Math.ceil(categories.length / 2));
+
+  const topTrack = document.querySelector<HTMLElement>(
+    '.category-carousel[data-row="top"] .category-track'
+  );
+  const bottomTrack = document.querySelector<HTMLElement>(
+    '.category-carousel[data-row="bottom"] .category-track'
+  );
+
+  if (topTrack) {
+    fillTrack(topTrack, topRow);
+  }
+  if (bottomTrack) {
+    fillTrack(bottomTrack, bottomRow);
+  }
+
+  const emptyState = document.getElementById("categoriesEmptyState");
+  const isEmpty = categories.length === 0;
+  if (emptyState) {
+    emptyState.hidden = !isEmpty;
+  }
+
+  const carousels = document.querySelectorAll<HTMLElement>(".category-carousel");
+  carousels.forEach((carousel) => {
+    if (isEmpty) {
+      carousel.classList.add("is-empty");
+    } else {
+      carousel.classList.remove("is-empty");
+    }
+  });
+
+  requestAnimationFrame(() => {
+    controls.forEach((control) => control.refresh());
+  });
+}
+
+function fillTrack(track: HTMLElement, categories: CategorySummary[]) {
+  track.innerHTML = "";
+  if (!categories.length) {
+    const placeholder = document.createElement("div");
+    placeholder.className = "category-track__placeholder";
+    placeholder.textContent = "No hay categorías en esta fila";
+    track.appendChild(placeholder);
+    return;
+  }
+
+  categories.forEach((category) => {
+    track.appendChild(createCategoryCard(category));
+  });
+}
+
+function createCategoryCard(category: CategorySummary) {
+  const card = document.createElement("article");
+  card.className = "category-card";
+  card.tabIndex = 0;
+  card.dataset.category = category.name;
+
+  const quantityFormatter = new Intl.NumberFormat("es-CO");
+  const currencyFormatter = new Intl.NumberFormat("es-CO", {
+    style: "currency",
+    currency: "COP",
+    maximumFractionDigits: 0,
+  });
+
+  card.innerHTML = `
+    <header class="category-card__header">
+      <h4>${category.name}</h4>
+      <span class="category-card__chip">${category.resourceCount} recursos</span>
+    </header>
+    <dl class="category-card__stats">
+      <div>
+        <dt>Total de unidades</dt>
+        <dd>${quantityFormatter.format(category.totalQuantity)}</dd>
+      </div>
+      <div>
+        <dt>Valor estimado</dt>
+        <dd>${currencyFormatter.format(category.totalValue)}</dd>
+      </div>
+      <div>
+        <dt>Recurso destacado</dt>
+        <dd>${category.topResource ?? "Sin especificar"}</dd>
+      </div>
+    </dl>
+    <footer class="category-card__footer">
+      <span>Ver recursos</span>
+      <span aria-hidden="true" class="category-card__arrow">→</span>
+    </footer>
+  `;
+
+  const navigate = () => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem("presetCategoria", category.name);
+    window.location.href = "/inventario";
+  };
+
+  card.addEventListener("click", navigate);
+  card.addEventListener("keydown", (event) => {
+    const key = (event as KeyboardEvent).key;
+    if (key === "Enter" || key === " " || key === "Spacebar") {
+      event.preventDefault();
+      navigate();
+    }
+  });
+
+  return card;
+}
+
+function setupCarousel(carousel: HTMLElement): CarouselControl {
+  const track = carousel.querySelector<HTMLElement>(".category-track");
+  const prev = carousel.querySelector<HTMLButtonElement>(".cat-nav.prev");
+  const next = carousel.querySelector<HTMLButtonElement>(".cat-nav.next");
+
+  if (!track || !prev || !next) {
+    return {
+      cleanup: () => {},
+      refresh: () => {},
+    };
+  }
+
+  const step = () => Math.max(track.clientWidth * 0.8, 200);
+
+  const scrollPrev = () => {
+    track.scrollBy({ left: -step(), behavior: "smooth" });
+  };
+
+  const scrollNext = () => {
+    track.scrollBy({ left: step(), behavior: "smooth" });
+  };
+
+  const updateControls = () => {
+    const { scrollLeft, scrollWidth, clientWidth } = track;
+    const maxScrollLeft = Math.max(0, scrollWidth - clientWidth - 1);
+    const hideButtons = scrollWidth <= clientWidth + 1;
+
+    prev.disabled = scrollLeft <= 0;
+    next.disabled = scrollLeft >= maxScrollLeft;
+
+    prev.classList.toggle("is-hidden", hideButtons);
+    next.classList.toggle("is-hidden", hideButtons);
+  };
+
+  prev.addEventListener("click", scrollPrev);
+  next.addEventListener("click", scrollNext);
+  track.addEventListener("scroll", updateControls);
+  window.addEventListener("resize", updateControls);
+
+  return {
+    cleanup: () => {
+      prev.removeEventListener("click", scrollPrev);
+      next.removeEventListener("click", scrollNext);
+      track.removeEventListener("scroll", updateControls);
+      window.removeEventListener("resize", updateControls);
+    },
+    refresh: () => {
+      updateControls();
+    },
+  };
+}
+
+function buildCategorySummaries(
+  inventory: InventoryItem[],
+  storedCategories: string[]
+): CategorySummary[] {
+  const normalizedCategories = new Map<string, string>();
+
+  const addCategory = (raw?: string) => {
+    const value = raw?.trim();
+    if (!value) return;
+    const key = value.toLowerCase();
+    if (!normalizedCategories.has(key)) {
+      normalizedCategories.set(key, value);
+    }
+  };
+
+  storedCategories.forEach((name) => addCategory(name));
+  inventory.forEach((item) => addCategory(item.categoria));
+
+  const categories = Array.from(normalizedCategories.values()).sort((a, b) =>
+    a.localeCompare(b, "es", { sensitivity: "base" })
+  );
+
+  return categories.map((name) => summarizeCategory(name, inventory));
+}
+
+function summarizeCategory(name: string, inventory: InventoryItem[]): CategorySummary {
+  const normalized = name.trim().toLowerCase();
+  const items = inventory.filter((item) => {
+    const categoryName = item.categoria?.trim().toLowerCase();
+    return categoryName === normalized;
+  });
+
+  const resourceCount = items.length;
+  const totalQuantity = items.reduce((acc, item) => acc + (item.cantidad ?? 0), 0);
+  const totalValue = items.reduce(
+    (acc, item) => acc + (item.cantidad ?? 0) * (item.precio ?? 0),
+    0
+  );
+
+  const topResource = items
+    .slice()
+    .sort((a, b) => (b.cantidad ?? 0) - (a.cantidad ?? 0))[0]?.recurso;
+
+  return {
+    name,
+    resourceCount,
+    totalQuantity,
+    totalValue,
+    topResource,
+  };
+}
+
+function loadJSON<T>(key: string, fallback: T): T {
+  try {
+    if (typeof window === "undefined") {
+      return fallback;
+    }
+    const raw = window.localStorage.getItem(key);
+    if (!raw) return fallback;
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    console.warn("Error leyendo almacenamiento", error);
+    return fallback;
+  }
+}
+
+function updateTheme(isDark: boolean) {
+  const body = document.body;
+  const label = document.getElementById("themeLabel");
+  if (isDark) {
+    body.setAttribute("data-theme", "dark");
+    window.localStorage.setItem("theme", "dark");
+    if (label) label.textContent = "Oscuro";
+  } else {
+    body.removeAttribute("data-theme");
+    window.localStorage.setItem("theme", "light");
+    if (label) label.textContent = "Claro";
+  }
+}
+
+function applyStoredTheme() {
+  const saved = window.localStorage.getItem("theme");
+  const toggle = document.getElementById("themeSwitch") as HTMLInputElement | null;
+  const label = document.getElementById("themeLabel");
+  if (saved === "dark") {
+    document.body.setAttribute("data-theme", "dark");
+    if (toggle) toggle.checked = true;
+    if (label) label.textContent = "Oscuro";
+  } else {
+    document.body.removeAttribute("data-theme");
+    if (toggle) toggle.checked = false;
+    if (label) label.textContent = "Claro";
+  }
+}
+
+function persistCategoryNames(names: string[]) {
+  try {
+    if (typeof window === "undefined") {
+      return;
+    }
+    window.localStorage.setItem(CATS_KEY, JSON.stringify(names));
+  } catch (error) {
+    console.warn("No fue posible guardar las categorías", error);
+  }
+}

--- a/frontend/src/app/categorias/page.tsx
+++ b/frontend/src/app/categorias/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+
+import { AnimatedBackground } from "../(auth)/login/components/AnimatedBackground";
+import { useBodyClass } from "../(auth)/login/hooks/useBodyClass";
+import { initializeCategoriesPage } from "./interaction";
+import "../(auth)/login/styles.css";
+import "../inventario/styles.css";
+import "./styles.css";
+
+export default function CategoriesPage() {
+  useBodyClass();
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const cleanup = initializeCategoriesPage();
+    return () => {
+      cleanup();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+    const layoutClass = "inventory-layout";
+    document.body.classList.add(layoutClass);
+    return () => {
+      document.body.classList.remove(layoutClass);
+    };
+  }, []);
+
+  return (
+    <>
+      <AnimatedBackground />
+      <div className="categories-page">
+        <header className="inventory-header">
+          <div className="inventory-header__inner">
+            <div className="header-bar">
+              <h1>Gestión de Inventario - Recursos Internos</h1>
+              <div className="header-actions">
+                <input type="checkbox" id="themeSwitch" hidden />
+                <label
+                  htmlFor="themeSwitch"
+                  className="switch"
+                  aria-label="Cambiar tema claro/oscuro"
+                />
+                <span id="themeLabel" className="theme-label">
+                  Claro
+                </span>
+              </div>
+            </div>
+            <nav>
+              <ul>
+                <li>
+                  <Link href="/inicio">Inicio</Link>
+                </li>
+                <li>
+                  <Link href="/inventario">Inventario</Link>
+                </li>
+                <li>
+                  <Link href="/categorias" aria-current="page">
+                    Categorías
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/presupuesto">Presupuesto</Link>
+                </li>
+              </ul>
+            </nav>
+          </div>
+        </header>
+
+        <div className="categories-shell">
+          <main className="categories-main">
+            <section className="categories-hero">
+              <div>
+                <h2>Categorías</h2>
+                <p>
+                  Haz clic en una tarjeta para ver únicamente los recursos de esa
+                  categoría dentro del inventario.
+                </p>
+              </div>
+              <p className="categories-hero__hint">
+                Actualiza las categorías desde el inventario. Los cambios se
+                sincronizan automáticamente.
+              </p>
+            </section>
+
+            <section className="categories-section">
+              <header className="categories-section__header">
+                <h3>Explora los recursos por categoría</h3>
+                <p>
+                  Navega entre los carruseles superiores e inferiores para
+                  identificar tendencias, cantidades disponibles y valor
+                  acumulado por cada segmento.
+                </p>
+              </header>
+
+              <div className="category-carousel" data-row="top">
+                <button className="cat-nav prev" aria-label="Anterior">
+                  ‹
+                </button>
+                <div className="category-track" />
+                <button className="cat-nav next" aria-label="Siguiente">
+                  ›
+                </button>
+              </div>
+
+              <div className="category-carousel" data-row="bottom">
+                <button className="cat-nav prev" aria-label="Anterior">
+                  ‹
+                </button>
+                <div className="category-track" />
+                <button className="cat-nav next" aria-label="Siguiente">
+                  ›
+                </button>
+              </div>
+
+              <p id="categoriesEmptyState" className="categories-empty" hidden>
+                No hay categorías registradas todavía. Agrega recursos en el
+                inventario para construir este resumen visual.
+              </p>
+            </section>
+          </main>
+
+          <footer className="categories-footer">
+            <p>Versión 1.1 - Proyecto Personal para Portafolio</p>
+          </footer>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/app/categorias/styles.css
+++ b/frontend/src/app/categorias/styles.css
@@ -1,0 +1,283 @@
+:root {
+  --categories-surface: rgba(10, 35, 60, 0.9);
+  --categories-border: rgba(80, 150, 220, 0.35);
+  --categories-text: #eaf2ff;
+  --categories-muted: #9bb4d3;
+  --categories-highlight: linear-gradient(135deg, #6d78ff, #2ad1ff);
+  --categories-shadow: 0 28px 60px rgba(0, 0, 0, 0.55);
+}
+
+body[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+.categories-page {
+  position: relative;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  color: var(--categories-text);
+}
+
+.categories-shell {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 120px 32px 72px;
+  box-sizing: border-box;
+}
+
+.categories-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 48px;
+}
+
+.categories-hero {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: var(--categories-surface);
+  border: 1px solid var(--categories-border);
+  border-radius: 22px;
+  padding: 32px;
+  box-shadow: var(--categories-shadow);
+  backdrop-filter: blur(16px);
+}
+
+.categories-hero h2 {
+  margin: 0 0 8px;
+  font-size: clamp(26px, 3vw, 36px);
+}
+
+.categories-hero p {
+  margin: 0;
+  color: var(--categories-muted);
+  line-height: 1.6;
+}
+
+.categories-hero__hint {
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 16px;
+  font-size: 0.95rem;
+}
+
+.categories-section {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.categories-section__header {
+  max-width: 780px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.categories-section__header h3 {
+  margin: 0;
+  font-size: clamp(20px, 2.6vw, 28px);
+}
+
+.categories-section__header p {
+  margin: 0;
+  color: var(--categories-muted);
+  line-height: 1.7;
+}
+
+.category-carousel {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  min-height: 260px;
+}
+
+.category-carousel.is-empty {
+  min-height: 120px;
+}
+
+.category-track {
+  display: flex;
+  gap: 20px;
+  overflow: hidden;
+  width: 100%;
+  padding: 12px 4px;
+}
+
+.category-track::-webkit-scrollbar {
+  display: none;
+}
+
+.category-track__placeholder {
+  width: 100%;
+  display: grid;
+  place-items: center;
+  color: var(--categories-muted);
+  font-style: italic;
+  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border-radius: 18px;
+  padding: 28px;
+  background: rgba(14, 32, 52, 0.6);
+}
+
+.cat-nav {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  border: 1px solid rgba(120, 160, 220, 0.45);
+  background: rgba(10, 25, 45, 0.72);
+  color: var(--categories-text);
+  font-size: 26px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+}
+
+.cat-nav:hover:not(:disabled) {
+  transform: translateY(-2px);
+  background: rgba(22, 44, 70, 0.88);
+}
+
+.cat-nav:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.cat-nav.is-hidden {
+  visibility: hidden;
+}
+
+.category-card {
+  min-width: min(320px, 80vw);
+  max-width: 360px;
+  background: var(--categories-surface);
+  border: 1px solid var(--categories-border);
+  border-radius: 22px;
+  padding: 24px;
+  box-shadow: var(--categories-shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  backdrop-filter: blur(12px);
+  cursor: pointer;
+  transition: transform 0.25s ease, border-color 0.25s ease,
+    box-shadow 0.25s ease;
+}
+
+.category-card:focus-visible,
+.category-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(120, 200, 255, 0.75);
+  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.6);
+  outline: none;
+}
+
+.category-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.category-card__header h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  line-height: 1.4;
+}
+
+.category-card__chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--categories-highlight);
+  color: #041325;
+  font-weight: 600;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.category-card__stats {
+  display: grid;
+  gap: 16px;
+}
+
+.category-card__stats dt {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(234, 242, 255, 0.66);
+}
+
+.category-card__stats dd {
+  margin: 6px 0 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.category-card__footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 12px;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  color: var(--categories-muted);
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.category-card__arrow {
+  font-size: 1.1rem;
+  transition: transform 0.25s ease;
+}
+
+.category-card:hover .category-card__arrow,
+.category-card:focus-visible .category-card__arrow {
+  transform: translateX(4px);
+}
+
+.categories-empty {
+  margin: 0;
+  padding: 20px;
+  border-radius: 18px;
+  background: rgba(8, 20, 38, 0.7);
+  border: 1px dashed rgba(120, 160, 220, 0.45);
+  color: var(--categories-muted);
+  text-align: center;
+}
+
+.categories-footer {
+  text-align: center;
+  color: var(--categories-muted);
+  font-size: 0.85rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 20px;
+  margin-top: auto;
+}
+
+@media (max-width: 768px) {
+  .categories-shell {
+    padding: 100px 20px 56px;
+  }
+
+  .categories-hero {
+    padding: 24px;
+  }
+
+  .category-card {
+    min-width: min(260px, 82vw);
+    padding: 20px;
+  }
+
+  .cat-nav {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `/categorias` page that mirrors the inventory header and introduces carousel rows for category exploration
- implement a client-side controller that reads inventory data, syncs with local storage, and renders interactive cards with navigation back to the inventory filter
- create scoped styles for the categories view, including responsive layouts and carousel controls

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbf058782083268085b43bb2162842