### PR TITLE
Add category and budget previews to home page

### DIFF
--- a/frontend/src/app/inicio/page.tsx
+++ b/frontend/src/app/inicio/page.tsx
@@ -17,6 +17,20 @@ type ResourcePreview = {
   info: string;
 };
 
+type CategoryPreview = {
+  name: string;
+  resources: number;
+  units: number;
+  value: number;
+};
+
+type BudgetSnapshot = {
+  label: string;
+  value: number | string;
+  detail: string;
+  trend?: "up" | "down";
+};
+
 const FEATURED_RESOURCES: ResourcePreview[] = [
   {
     id: 1,
@@ -41,6 +55,47 @@ const FEATURED_RESOURCES: ResourcePreview[] = [
     quantity: 3,
     price: 189000,
     info: "Tablero listo para montaje en terreno",
+  },
+];
+
+const CATEGORY_PREVIEW: CategoryPreview[] = [
+  {
+    name: "Materiales eléctricos",
+    resources: 18,
+    units: 84,
+    value: 4280000,
+  },
+  {
+    name: "Bombas de agua",
+    resources: 9,
+    units: 21,
+    value: 3515000,
+  },
+  {
+    name: "Herramientas especializadas",
+    resources: 6,
+    units: 32,
+    value: 1458000,
+  },
+];
+
+const BUDGET_SNAPSHOT: BudgetSnapshot[] = [
+  {
+    label: "Ejecución trimestral",
+    value: "54%",
+    detail: "Meta Q2: 62%",
+    trend: "up",
+  },
+  {
+    label: "Gasto del mes",
+    value: 1875000,
+    detail: "Abril 2024",
+    trend: "down",
+  },
+  {
+    label: "Saldo disponible",
+    value: 1640000,
+    detail: "Reservado para urgencias",
   },
 ];
 
@@ -239,6 +294,23 @@ export default function InicioPage() {
                 Explora el carrusel de categorías para segmentar recursos, asignar
                 responsables y activar filtros preconfigurados según cada área.
               </p>
+              <div className="home-panel__preview" aria-label="Resumen rápido de categorías">
+                <ul className="category-preview">
+                  {CATEGORY_PREVIEW.map((category) => (
+                    <li key={category.name} className="category-preview__item">
+                      <div>
+                        <p className="category-preview__name">{category.name}</p>
+                        <p className="category-preview__meta">
+                          {category.resources} recursos · {category.units} unidades
+                        </p>
+                      </div>
+                      <p className="category-preview__value">
+                        {currencyFormatter.format(category.value)}
+                      </p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
               <Link href="/categorias">Explorar categorías</Link>
             </article>
             <article className="home-panel">
@@ -247,6 +319,31 @@ export default function InicioPage() {
                 Visualiza el impacto financiero de los insumos mediante gráficas
                 y KPI en la sección de presupuesto.
               </p>
+              <div className="home-panel__preview" aria-label="Indicadores financieros destacados">
+                <ul className="budget-preview">
+                  {BUDGET_SNAPSHOT.map((item) => (
+                    <li key={item.label} className="budget-preview__item">
+                      <div className="budget-preview__header">
+                        <p className="budget-preview__label">{item.label}</p>
+                        {item.trend ? (
+                          <span
+                            className={`budget-preview__trend budget-preview__trend--${item.trend}`}
+                            aria-hidden="true"
+                          >
+                            {item.trend === "up" ? "▲" : "▼"}
+                          </span>
+                        ) : null}
+                      </div>
+                      <p className="budget-preview__value">
+                        {typeof item.value === "number"
+                          ? currencyFormatter.format(item.value)
+                          : item.value}
+                      </p>
+                      <p className="budget-preview__detail">{item.detail}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
               <Link href="/presupuesto">Abrir presupuesto</Link>
             </article>
           </section>

--- a/frontend/src/app/inicio/styles.css
+++ b/frontend/src/app/inicio/styles.css
@@ -369,6 +369,97 @@ input[type="checkbox"]:checked + .switch::after {
   line-height: 1.6;
 }
 
+.home-panel__preview {
+  margin-top: 6px;
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(10, 45, 78, 0.72);
+  border: 1px solid rgba(86, 142, 206, 0.32);
+  box-shadow: inset 0 0 0 1px rgba(86, 142, 206, 0.12);
+}
+
+.category-preview,
+.budget-preview {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.category-preview__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.category-preview__name {
+  margin: 0;
+  font-weight: 600;
+  color: #fff;
+}
+
+.category-preview__meta {
+  margin: 4px 0 0;
+  font-size: 13px;
+  color: var(--home-muted);
+}
+
+.category-preview__value {
+  margin: 0;
+  font-weight: 600;
+  color: #fff;
+  white-space: nowrap;
+}
+
+.budget-preview__item {
+  display: grid;
+  gap: 4px;
+}
+
+.budget-preview__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.budget-preview__label {
+  margin: 0;
+  font-size: 14px;
+  color: var(--home-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+
+.budget-preview__trend {
+  font-size: 12px;
+  line-height: 1;
+}
+
+.budget-preview__trend--up {
+  color: #38e0a3;
+}
+
+.budget-preview__trend--down {
+  color: #ff8f8f;
+}
+
+.budget-preview__value {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.budget-preview__detail {
+  margin: 0;
+  font-size: 13px;
+  color: var(--home-muted);
+}
+
 .home-panel a {
   margin-top: auto;
   align-self: flex-start;


### PR DESCRIPTION
## Summary
- add compact preview data for key categories on the home page
- surface quick budget KPIs alongside the existing inventory snapshot
- style the new preview sections to match the current home layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbf9419b048326a25a3f5ad7d420c1