### PR TITLE
Add custom 404 not found page

### DIFF
--- a/frontend/src/app/not-found.css
+++ b/frontend/src/app/not-found.css
@@ -1,0 +1,155 @@
+.not-found {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background:
+    radial-gradient(1400px 800px at 80% 120%, rgba(42, 209, 255, 0.12), transparent 65%),
+    radial-gradient(1200px 700px at 20% -20%, rgba(109, 120, 255, 0.18), transparent 70%),
+    linear-gradient(160deg, #041321 0%, #0a2946 55%, #0d3b4e 100%);
+  color: #eaf2ff;
+  position: relative;
+  overflow: hidden;
+}
+
+.not-found__glow {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.5;
+  background:
+    radial-gradient(60% 55% at 50% 0%, rgba(42, 209, 255, 0.25), transparent 70%),
+    radial-gradient(65% 40% at 50% 100%, rgba(109, 120, 255, 0.22), transparent 75%);
+  filter: blur(90px);
+  transform: scale(1.1);
+}
+
+.not-found__card {
+  position: relative;
+  z-index: 1;
+  max-width: 560px;
+  width: min(560px, 92vw);
+  padding: 40px 36px;
+  background: rgba(8, 28, 48, 0.78);
+  border: 1px solid rgba(80, 160, 220, 0.3);
+  border-radius: 24px;
+  box-shadow:
+    0 30px 80px rgba(0, 0, 0, 0.65),
+    inset 0 1px 0 rgba(255, 255, 255, 0.05);
+  display: grid;
+  gap: 18px;
+  backdrop-filter: blur(12px);
+}
+
+.not-found__tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: fit-content;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(42, 209, 255, 0.12);
+  border: 1px solid rgba(42, 209, 255, 0.4);
+  color: #7ad8ff;
+}
+
+.not-found__title {
+  font-size: clamp(28px, 5vw, 40px);
+  font-weight: 800;
+  line-height: 1.1;
+  margin: 0;
+  text-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+.not-found__description {
+  margin: 0;
+  color: rgba(223, 236, 255, 0.82);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.not-found__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.not-found__button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 18px;
+  border-radius: 14px;
+  font-weight: 700;
+  font-size: 15px;
+  text-decoration: none;
+  color: #fff;
+  background: linear-gradient(120deg, #6d78ff 0%, #2ad1ff 100%);
+  box-shadow: 0 20px 45px rgba(42, 209, 255, 0.28);
+  transition: transform 0.12s ease, filter 0.18s ease;
+}
+
+.not-found__button:hover {
+  filter: brightness(1.05);
+}
+
+.not-found__button:active {
+  transform: translateY(1px);
+}
+
+.not-found__secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 16px;
+  border-radius: 14px;
+  font-weight: 600;
+  font-size: 15px;
+  text-decoration: none;
+  color: #a6c7ff;
+  border: 1px solid rgba(166, 199, 255, 0.35);
+  background: rgba(9, 34, 58, 0.6);
+  transition: border-color 0.18s ease, color 0.18s ease, transform 0.12s ease;
+}
+
+.not-found__secondary:hover {
+  color: #d2e7ff;
+  border-color: rgba(210, 231, 255, 0.6);
+}
+
+.not-found__secondary:active {
+  transform: translateY(1px);
+}
+
+.not-found__hint {
+  font-size: 13px;
+  color: rgba(195, 218, 247, 0.7);
+  margin-top: 4px;
+}
+
+@media (max-width: 640px) {
+  .not-found {
+    padding: 24px;
+  }
+
+  .not-found__card {
+    padding: 32px 26px;
+    border-radius: 20px;
+  }
+
+  .not-found__actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .not-found__secondary,
+  .not-found__button {
+    width: 100%;
+    justify-content: center;
+  }
+}

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,33 @@
+import Link from "next/link";
+
+import "./not-found.css";
+
+export default function NotFound() {
+  return (
+    <main className="not-found" role="main">
+      <div className="not-found__glow" aria-hidden />
+      <section className="not-found__card" aria-labelledby="not-found-title">
+        <span className="not-found__tag">Error 404</span>
+        <h1 id="not-found-title" className="not-found__title">
+          Página no encontrada
+        </h1>
+        <p className="not-found__description">
+          La dirección que intentas abrir no existe o fue movida. Revisa el enlace
+          ingresado o vuelve al panel principal para continuar trabajando.
+        </p>
+        <div className="not-found__actions">
+          <Link className="not-found__button" href="/inicio">
+            Volver al inicio
+          </Link>
+          <Link className="not-found__secondary" href="/inventario">
+            Ir al inventario
+          </Link>
+        </div>
+        <p className="not-found__hint">
+          ¿Necesitas ayuda? Ponte en contacto con soporte interno para reportar el
+          enlace roto.
+        </p>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated global 404 page for the Next.js frontend
- include gradient styling and clear navigation actions back to main sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbfed8730083269cbf367887998ed5