### PR TITLE
Add light theme styling and refreshed logo

### DIFF
--- a/frontend/public/logo-servigenman.svg
+++ b/frontend/public/logo-servigenman.svg
@@ -1,19 +1,54 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
   <defs>
-    <linearGradient id="bg" x1="12%" y1="10%" x2="88%" y2="88%">
-      <stop offset="0%" stop-color="#7b5cff"/>
-      <stop offset="100%" stop-color="#26c4ff"/>
+    <radialGradient id="shadow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.0" />
+      <stop offset="65%" stop-color="#ffffff" stop-opacity="0.0" />
+      <stop offset="100%" stop-color="#02040a" stop-opacity="0.9" />
+    </radialGradient>
+    <radialGradient id="disc" cx="50%" cy="50%" r="48%">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="70%" stop-color="#f8fbff" />
+      <stop offset="100%" stop-color="#e6f2ff" />
+    </radialGradient>
+    <linearGradient id="pumpBody" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0d5e8e" />
+      <stop offset="100%" stop-color="#1a91c6" />
     </linearGradient>
-    <linearGradient id="bolt" x1="24%" y1="0%" x2="82%" y2="88%">
-      <stop offset="0%" stop-color="#f7fbff"/>
-      <stop offset="100%" stop-color="#bfe3ff"/>
+    <linearGradient id="pumpAccent" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#f76754" />
+      <stop offset="100%" stop-color="#d94a3b" />
+    </linearGradient>
+    <linearGradient id="tower" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#7f8ba0" />
+      <stop offset="100%" stop-color="#4f6079" />
+    </linearGradient>
+    <linearGradient id="pipe" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0f5a84" />
+      <stop offset="100%" stop-color="#083754" />
     </linearGradient>
   </defs>
-  <rect x="64" y="64" width="384" height="384" rx="104" fill="url(#bg)"/>
-  <g transform="translate(140 124)">
-    <path d="M160 0L104 112h64l-24 144 112-160h-68L160 0z" fill="url(#bolt)"/>
-    <circle cx="56" cy="248" r="40" fill="rgba(255,255,255,0.2)"/>
-    <circle cx="56" cy="248" r="16" fill="#ffffff"/>
-    <rect x="128" y="216" width="60" height="60" rx="14" fill="rgba(255,255,255,0.35)"/>
+  <rect width="512" height="512" fill="url(#shadow)" />
+  <circle cx="256" cy="256" r="210" fill="url(#disc)" />
+  <g transform="translate(108 160)">
+    <rect x="64" y="132" width="168" height="24" rx="12" fill="#0a2f4c" />
+    <rect x="84" y="92" width="112" height="64" rx="30" fill="url(#pumpBody)" />
+    <rect x="120" y="72" width="40" height="28" rx="10" fill="url(#pumpAccent)" />
+    <path d="M84 124h-32c-18 0-32 14-32 32v20h24v-18c0-5 4-9 10-9h30z" fill="url(#pipe)" />
+    <path d="M196 124h38c18 0 32 14 32 32v20h-24v-18c0-5-4-9-10-9h-36z" fill="url(#pipe)" />
+    <circle cx="140" cy="124" r="18" fill="#0a2f4c" />
+    <circle cx="140" cy="124" r="8" fill="#fefefe" />
+    <g transform="translate(208 0)">
+      <rect x="0" y="0" width="96" height="120" rx="16" fill="url(#tower)" />
+      <rect x="14" y="18" width="30" height="40" rx="6" fill="#0f5a84" />
+      <rect x="52" y="18" width="30" height="40" rx="6" fill="#0f5a84" />
+      <circle cx="29" cy="86" r="8" fill="#f76754" />
+      <circle cx="67" cy="86" r="8" fill="#36d3a5" />
+      <path d="M29 52v18" stroke="#fefefe" stroke-width="4" stroke-linecap="round" />
+      <path d="M67 52v18" stroke="#fefefe" stroke-width="4" stroke-linecap="round" />
+    </g>
+    <path d="M70 36c-10-12-3-28 12-32 8-2 16 1 22 6 6-11 20-16 32-11 14 6 20 22 12 35-9 16-42 41-42 41s-31-22-38-39z" fill="#1aa5d6" />
+    <path d="M94 2c7 2 13 7 16 14 6-11 20-16 32-11 11 5 17 15 16 26 6-12 1-27-12-34-12-6-26-1-34 9-4-4-9-7-15-9z" fill="#57d0ff" opacity="0.7" />
   </g>
+  <text x="256" y="360" fill="#0e3f66" font-family="'Inter', 'Segoe UI', sans-serif" font-size="46" font-weight="800" text-anchor="middle">SERVI<tspan fill="#1aa5d6">GENMAN</tspan></text>
+  <text x="256" y="398" fill="#4f6580" font-family="'Inter', 'Segoe UI', sans-serif" font-size="20" font-weight="600" text-anchor="middle">MANTENIMIENTO DE BOMBAS Y SERVICIOS ELÉCTRICOS</text>
 </svg>

--- a/frontend/src/app/categorias/styles.css
+++ b/frontend/src/app/categorias/styles.css
@@ -1,13 +1,43 @@
 :root {
+  --categories-surface: rgba(255, 255, 255, 0.95);
+  --categories-border: rgba(32, 110, 190, 0.2);
+  --categories-text: #10253e;
+  --categories-muted: #56677f;
+  --categories-highlight: linear-gradient(135deg, #2e78ff, #1ac6ff);
+  --categories-shadow: 0 20px 48px rgba(18, 43, 72, 0.16);
+  --categories-divider: rgba(30, 110, 190, 0.18);
+  --categories-placeholder-bg: rgba(234, 244, 255, 0.75);
+  --categories-placeholder-border: rgba(30, 110, 190, 0.2);
+  --categories-nav-border: rgba(30, 110, 190, 0.25);
+  --categories-nav-bg: rgba(30, 110, 190, 0.12);
+  --categories-nav-hover: rgba(30, 110, 190, 0.2);
+  --categories-stat-label: rgba(16, 38, 63, 0.6);
+  --categories-card-hover-border: rgba(46, 150, 255, 0.6);
+  --categories-card-hover-shadow: 0 28px 70px rgba(18, 43, 72, 0.2);
+  --categories-empty-bg: rgba(245, 250, 255, 0.9);
+  --categories-empty-border: rgba(30, 110, 190, 0.25);
+  --categories-footer-color: rgba(18, 44, 72, 0.7);
+}
+
+body[data-theme="dark"] {
   --categories-surface: rgba(10, 35, 60, 0.9);
   --categories-border: rgba(80, 150, 220, 0.35);
   --categories-text: #eaf2ff;
   --categories-muted: #9bb4d3;
   --categories-highlight: linear-gradient(135deg, #6d78ff, #2ad1ff);
   --categories-shadow: 0 28px 60px rgba(0, 0, 0, 0.55);
-}
-
-body[data-theme="dark"] {
+  --categories-divider: rgba(255, 255, 255, 0.08);
+  --categories-placeholder-bg: rgba(14, 32, 52, 0.6);
+  --categories-placeholder-border: rgba(255, 255, 255, 0.15);
+  --categories-nav-border: rgba(120, 160, 220, 0.45);
+  --categories-nav-bg: rgba(10, 25, 45, 0.72);
+  --categories-nav-hover: rgba(22, 44, 70, 0.88);
+  --categories-stat-label: rgba(234, 242, 255, 0.66);
+  --categories-card-hover-border: rgba(120, 200, 255, 0.75);
+  --categories-card-hover-shadow: 0 28px 70px rgba(0, 0, 0, 0.6);
+  --categories-empty-bg: rgba(8, 20, 38, 0.7);
+  --categories-empty-border: rgba(120, 160, 220, 0.45);
+  --categories-footer-color: var(--categories-muted);
   color-scheme: dark;
 }
 
@@ -62,7 +92,7 @@ body[data-theme="dark"] {
 }
 
 .categories-hero__hint {
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--categories-divider);
   padding-top: 16px;
   font-size: 0.95rem;
 }
@@ -121,18 +151,18 @@ body[data-theme="dark"] {
   place-items: center;
   color: var(--categories-muted);
   font-style: italic;
-  border: 1px dashed rgba(255, 255, 255, 0.15);
+  border: 1px dashed var(--categories-placeholder-border);
   border-radius: 18px;
   padding: 28px;
-  background: rgba(14, 32, 52, 0.6);
+  background: var(--categories-placeholder-bg);
 }
 
 .cat-nav {
   width: 44px;
   height: 44px;
   border-radius: 50%;
-  border: 1px solid rgba(120, 160, 220, 0.45);
-  background: rgba(10, 25, 45, 0.72);
+  border: 1px solid var(--categories-nav-border);
+  background: var(--categories-nav-bg);
   color: var(--categories-text);
   font-size: 26px;
   display: inline-flex;
@@ -145,7 +175,7 @@ body[data-theme="dark"] {
 
 .cat-nav:hover:not(:disabled) {
   transform: translateY(-2px);
-  background: rgba(22, 44, 70, 0.88);
+  background: var(--categories-nav-hover);
 }
 
 .cat-nav:disabled {
@@ -177,8 +207,8 @@ body[data-theme="dark"] {
 .category-card:focus-visible,
 .category-card:hover {
   transform: translateY(-6px);
-  border-color: rgba(120, 200, 255, 0.75);
-  box-shadow: 0 28px 70px rgba(0, 0, 0, 0.6);
+  border-color: var(--categories-card-hover-border);
+  box-shadow: var(--categories-card-hover-shadow);
   outline: none;
 }
 
@@ -214,7 +244,7 @@ body[data-theme="dark"] {
   font-size: 0.78rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
-  color: rgba(234, 242, 255, 0.66);
+  color: var(--categories-stat-label);
 }
 
 .category-card__stats dd {
@@ -228,7 +258,7 @@ body[data-theme="dark"] {
   align-items: center;
   justify-content: space-between;
   padding-top: 12px;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--categories-divider);
   color: var(--categories-muted);
   font-weight: 600;
   font-size: 0.92rem;
@@ -248,17 +278,17 @@ body[data-theme="dark"] {
   margin: 0;
   padding: 20px;
   border-radius: 18px;
-  background: rgba(8, 20, 38, 0.7);
-  border: 1px dashed rgba(120, 160, 220, 0.45);
+  background: var(--categories-empty-bg);
+  border: 1px dashed var(--categories-empty-border);
   color: var(--categories-muted);
   text-align: center;
 }
 
 .categories-footer {
   text-align: center;
-  color: var(--categories-muted);
+  color: var(--categories-footer-color);
   font-size: 0.85rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-top: 1px solid var(--categories-divider);
   padding-top: 20px;
   margin-top: auto;
 }

--- a/frontend/src/app/inicio/styles.css
+++ b/frontend/src/app/inicio/styles.css
@@ -1,4 +1,62 @@
 :root {
+  --home-bg: rgba(255, 255, 255, 0.88);
+  --home-surface: rgba(255, 255, 255, 0.94);
+  --home-border: rgba(30, 102, 190, 0.18);
+  --home-text: #11263f;
+  --home-muted: #51627c;
+  --home-shadow: 0 20px 48px rgba(18, 43, 72, 0.18);
+  --home-accent: linear-gradient(120deg, #2e78ff, #1ac6ff);
+  --home-table-stripe: rgba(30, 110, 190, 0.08);
+  --home-table-border: rgba(30, 102, 190, 0.2);
+  --home-panel: rgba(246, 251, 255, 0.92);
+  --home-header-shadow: 0 14px 36px rgba(15, 42, 70, 0.16);
+  --home-header-sheen: linear-gradient(
+    120deg,
+    rgba(70, 140, 220, 0.16),
+    rgba(26, 198, 255, 0.14)
+  );
+  --home-switch-bg: rgba(200, 215, 235, 0.8);
+  --home-switch-border: rgba(140, 170, 210, 0.6);
+  --home-switch-knob: linear-gradient(120deg, #2e78ff, #1ac6ff);
+  --home-switch-knob-shadow: 0 4px 12px rgba(30, 110, 190, 0.22);
+  --home-badge-bg: rgba(46, 120, 255, 0.14);
+  --home-cta-shadow: 0 18px 36px rgba(30, 150, 240, 0.25);
+  --home-secondary-bg: rgba(30, 110, 190, 0.08);
+  --home-secondary-border: rgba(30, 110, 190, 0.18);
+  --home-summary-bg: rgba(255, 255, 255, 0.96);
+  --home-summary-border: rgba(30, 102, 190, 0.18);
+  --home-summary-value: #10345c;
+  --home-preview-link-border: rgba(30, 110, 190, 0.3);
+  --home-preview-link-hover-bg: rgba(30, 110, 190, 0.12);
+  --home-panel-border: rgba(30, 102, 190, 0.22);
+  --home-panel-preview-bg: rgba(30, 110, 190, 0.12);
+  --home-panel-preview-border: rgba(30, 110, 190, 0.18);
+  --home-panel-preview-shadow: inset 0 0 0 1px rgba(30, 110, 190, 0.08);
+  --home-emphasis: #10345c;
+  --home-budget-positive: #1f9d77;
+  --home-budget-negative: #d75c5c;
+  --home-budget-value: #10345c;
+  --home-panel-link-border: rgba(30, 110, 190, 0.35);
+  --home-panel-link-hover-color: #0f2f58;
+  --home-panel-link-hover-border: rgba(30, 110, 190, 0.55);
+  --home-footer-color: rgba(18, 44, 72, 0.7);
+  --ocean-deep: #e3f3ff;
+  --ocean-mid: #f0f7ff;
+  --ocean-teal: #f7fbff;
+  --ink: var(--home-text);
+  --muted: var(--home-muted);
+  --card: rgba(255, 255, 255, 0.98);
+  --card-border: rgba(30, 102, 190, 0.16);
+  --field: rgba(255, 255, 255, 0.92);
+  --field-b: rgba(30, 102, 190, 0.24);
+  --btn-a: #2e78ff;
+  --btn-b: #1ac6ff;
+  --wave-a: rgba(46, 120, 255, 0.7);
+  --wave-b: rgba(26, 198, 255, 0.6);
+  --shadow: 0 20px 48px rgba(18, 43, 72, 0.18);
+}
+
+body[data-theme="dark"] {
   --home-bg: rgba(8, 26, 45, 0.75);
   --home-surface: rgba(10, 35, 60, 0.9);
   --home-border: rgba(86, 142, 206, 0.4);
@@ -7,7 +65,53 @@
   --home-shadow: 0 24px 60px rgba(0, 0, 0, 0.45);
   --home-accent: linear-gradient(120deg, #6d78ff, #2ad1ff);
   --home-table-stripe: rgba(28, 62, 96, 0.45);
+  --home-table-border: rgba(90, 140, 200, 0.25);
   --home-panel: rgba(8, 30, 52, 0.82);
+  --home-header-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+  --home-header-sheen: linear-gradient(
+    120deg,
+    rgba(109, 120, 255, 0.14),
+    rgba(42, 209, 255, 0.12)
+  );
+  --home-switch-bg: rgba(120, 160, 220, 0.3);
+  --home-switch-border: rgba(90, 130, 190, 0.45);
+  --home-switch-knob: linear-gradient(120deg, #7b5cff, #26c4ff);
+  --home-switch-knob-shadow: 0 6px 18px rgba(42, 209, 255, 0.3);
+  --home-badge-bg: rgba(109, 120, 255, 0.18);
+  --home-cta-shadow: 0 20px 40px rgba(42, 209, 255, 0.25);
+  --home-secondary-bg: rgba(255, 255, 255, 0.08);
+  --home-secondary-border: rgba(255, 255, 255, 0.12);
+  --home-summary-bg: rgba(12, 38, 62, 0.9);
+  --home-summary-border: rgba(90, 140, 200, 0.35);
+  --home-summary-value: #fff;
+  --home-preview-link-border: rgba(120, 170, 240, 0.45);
+  --home-preview-link-hover-bg: rgba(120, 170, 240, 0.12);
+  --home-panel-border: rgba(86, 142, 206, 0.35);
+  --home-panel-preview-bg: rgba(10, 45, 78, 0.72);
+  --home-panel-preview-border: rgba(86, 142, 206, 0.32);
+  --home-panel-preview-shadow: inset 0 0 0 1px rgba(86, 142, 206, 0.12);
+  --home-emphasis: #fff;
+  --home-budget-positive: #38e0a3;
+  --home-budget-negative: #ff8f8f;
+  --home-budget-value: #fff;
+  --home-panel-link-border: rgba(109, 120, 255, 0.6);
+  --home-panel-link-hover-color: #fff;
+  --home-panel-link-hover-border: rgba(160, 190, 255, 0.8);
+  --home-footer-color: #8ea8c9;
+  --ocean-deep: #051a2c;
+  --ocean-mid: #0a2e4a;
+  --ocean-teal: #0b3e4a;
+  --ink: #eaf2ff;
+  --muted: #b9c8e6;
+  --card: #0e2b49;
+  --card-border: #1d456b;
+  --field: #0d2742;
+  --field-b: #1a3a5a;
+  --btn-a: #6d78ff;
+  --btn-b: #2ad1ff;
+  --wave-a: #2ad1ff;
+  --wave-b: #6d78ff;
+  --shadow: 0 24px 70px rgba(0, 0, 0, 0.55);
 }
 
 body.servigenman-login.home-layout {
@@ -15,6 +119,11 @@ body.servigenman-login.home-layout {
   min-height: 100vh;
   padding: 0;
   overflow-y: auto;
+  color-scheme: light;
+}
+
+body.servigenman-login.home-layout[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 .home-page {
@@ -33,7 +142,7 @@ body.servigenman-login.home-layout {
   background: var(--home-bg);
   border-bottom: 1px solid var(--home-border);
   backdrop-filter: blur(16px);
-  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--home-header-shadow);
 }
 
 .home-header::before {
@@ -41,11 +150,7 @@ body.servigenman-login.home-layout {
   position: absolute;
   inset: 0;
   pointer-events: none;
-  background: linear-gradient(
-    120deg,
-    rgba(109, 120, 255, 0.14),
-    rgba(42, 209, 255, 0.12)
-  );
+  background: var(--home-header-sheen);
   opacity: 0.45;
 }
 
@@ -87,8 +192,8 @@ body.servigenman-login.home-layout {
   width: 44px;
   height: 24px;
   border-radius: 20px;
-  background: rgba(120, 160, 220, 0.3);
-  border: 1px solid rgba(90, 130, 190, 0.45);
+  background: var(--home-switch-bg);
+  border: 1px solid var(--home-switch-border);
   display: inline-flex;
   align-items: center;
   padding: 3px;
@@ -102,8 +207,8 @@ body.servigenman-login.home-layout {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: linear-gradient(120deg, #7b5cff, #26c4ff);
-  box-shadow: 0 6px 18px rgba(42, 209, 255, 0.3);
+  background: var(--home-switch-knob);
+  box-shadow: var(--home-switch-knob-shadow);
   transform: translateX(0);
   transition: transform 0.2s ease;
 }
@@ -175,7 +280,7 @@ input[type="checkbox"]:checked + .switch::after {
   display: inline-block;
   padding: 4px 12px;
   border-radius: 999px;
-  background: rgba(109, 120, 255, 0.18);
+  background: var(--home-badge-bg);
   color: var(--home-text);
   font-size: 13px;
   margin-bottom: 16px;
@@ -217,13 +322,13 @@ input[type="checkbox"]:checked + .switch::after {
 .home-cta {
   background: var(--home-accent);
   color: #fff;
-  box-shadow: 0 20px 40px rgba(42, 209, 255, 0.25);
+  box-shadow: var(--home-cta-shadow);
 }
 
 .home-secondary {
-  background: rgba(255, 255, 255, 0.08);
+  background: var(--home-secondary-bg);
   color: var(--home-text);
-  border: 1px solid rgba(255, 255, 255, 0.12);
+  border: 1px solid var(--home-secondary-border);
 }
 
 .home-cta:hover,
@@ -238,8 +343,8 @@ input[type="checkbox"]:checked + .switch::after {
 }
 
 .home-summary {
-  background: rgba(12, 38, 62, 0.9);
-  border: 1px solid rgba(90, 140, 200, 0.35);
+  background: var(--home-summary-bg);
+  border: 1px solid var(--home-summary-border);
   border-radius: 16px;
   padding: 24px;
 }
@@ -256,7 +361,7 @@ input[type="checkbox"]:checked + .switch::after {
   margin: 12px 0 8px;
   font-size: clamp(28px, 5vw, 36px);
   font-weight: 700;
-  color: #fff;
+  color: var(--home-summary-value);
 }
 
 .summary-caption {
@@ -300,14 +405,14 @@ input[type="checkbox"]:checked + .switch::after {
   align-self: flex-start;
   padding: 10px 18px;
   border-radius: 12px;
-  border: 1px solid rgba(120, 170, 240, 0.45);
+  border: 1px solid var(--home-preview-link-border);
   color: var(--home-text);
   text-decoration: none;
   transition: background 0.2s ease, transform 0.15s ease;
 }
 
 .home-preview__link:hover {
-  background: rgba(120, 170, 240, 0.12);
+  background: var(--home-preview-link-hover-bg);
   transform: translateY(-1px);
 }
 
@@ -325,7 +430,7 @@ input[type="checkbox"]:checked + .switch::after {
 .home-preview__table td {
   padding: 14px 16px;
   text-align: left;
-  border-bottom: 1px solid rgba(90, 140, 200, 0.25);
+  border-bottom: 1px solid var(--home-table-border);
   color: var(--home-text);
   font-size: 14px;
 }
@@ -349,7 +454,7 @@ input[type="checkbox"]:checked + .switch::after {
 
 .home-panel {
   background: var(--home-panel);
-  border: 1px solid rgba(86, 142, 206, 0.35);
+  border: 1px solid var(--home-panel-border);
   border-radius: 18px;
   padding: 28px;
   box-shadow: var(--home-shadow);
@@ -373,9 +478,9 @@ input[type="checkbox"]:checked + .switch::after {
   margin-top: 6px;
   padding: 16px;
   border-radius: 14px;
-  background: rgba(10, 45, 78, 0.72);
-  border: 1px solid rgba(86, 142, 206, 0.32);
-  box-shadow: inset 0 0 0 1px rgba(86, 142, 206, 0.12);
+  background: var(--home-panel-preview-bg);
+  border: 1px solid var(--home-panel-preview-border);
+  box-shadow: var(--home-panel-preview-shadow);
 }
 
 .category-preview,
@@ -398,7 +503,7 @@ input[type="checkbox"]:checked + .switch::after {
 .category-preview__name {
   margin: 0;
   font-weight: 600;
-  color: #fff;
+  color: var(--home-emphasis);
 }
 
 .category-preview__meta {
@@ -410,7 +515,7 @@ input[type="checkbox"]:checked + .switch::after {
 .category-preview__value {
   margin: 0;
   font-weight: 600;
-  color: #fff;
+  color: var(--home-emphasis);
   white-space: nowrap;
 }
 
@@ -440,18 +545,18 @@ input[type="checkbox"]:checked + .switch::after {
 }
 
 .budget-preview__trend--up {
-  color: #38e0a3;
+  color: var(--home-budget-positive);
 }
 
 .budget-preview__trend--down {
-  color: #ff8f8f;
+  color: var(--home-budget-negative);
 }
 
 .budget-preview__value {
   margin: 0;
   font-size: 20px;
   font-weight: 600;
-  color: #fff;
+  color: var(--home-budget-value);
 }
 
 .budget-preview__detail {
@@ -466,13 +571,14 @@ input[type="checkbox"]:checked + .switch::after {
   color: var(--home-text);
   text-decoration: none;
   font-weight: 600;
-  border-bottom: 1px solid rgba(109, 120, 255, 0.6);
+  border-bottom: 1px solid var(--home-panel-link-border);
   padding-bottom: 4px;
   transition: color 0.2s ease;
 }
 
 .home-panel a:hover {
-  color: #fff;
+  color: var(--home-panel-link-hover-color);
+  border-color: var(--home-panel-link-hover-border);
 }
 
 .home-footer {
@@ -480,7 +586,7 @@ input[type="checkbox"]:checked + .switch::after {
   padding: 24px 32px 40px;
   text-align: center;
   font-size: 13px;
-  color: var(--home-muted);
+  color: var(--home-footer-color);
 }
 
 @media (max-width: 960px) {

--- a/frontend/src/app/inventario/styles.css
+++ b/frontend/src/app/inventario/styles.css
@@ -1,4 +1,53 @@
 :root {
+  --inventory-bg: rgba(255, 255, 255, 0.92);
+  --inventory-panel: rgba(255, 255, 255, 0.95);
+  --inventory-border: rgba(32, 110, 190, 0.18);
+  --inventory-text: #10263f;
+  --inventory-muted: #556784;
+  --inventory-accent: linear-gradient(120deg, #2e78ff, #1ac6ff);
+  --inventory-danger: #d65c5c;
+  --inventory-success: #1f9d77;
+  --inventory-shadow: 0 18px 42px rgba(18, 43, 72, 0.16);
+  --inventory-surface: rgba(247, 251, 255, 0.94);
+  --inventory-input-bg: rgba(255, 255, 255, 0.95);
+  --inventory-input-border: rgba(32, 110, 190, 0.24);
+  --inventory-chip: rgba(46, 120, 255, 0.14);
+  --inventory-header-bg: rgba(255, 255, 255, 0.9);
+  --inventory-header-shadow: 0 12px 28px rgba(18, 43, 72, 0.15);
+  --inventory-header-sheen: linear-gradient(
+    120deg,
+    rgba(70, 140, 220, 0.18),
+    rgba(26, 198, 255, 0.14)
+  );
+  --inventory-switch-bg: rgba(200, 215, 235, 0.8);
+  --inventory-switch-border: rgba(140, 170, 210, 0.6);
+  --inventory-switch-knob: linear-gradient(135deg, #2e78ff, #1ac6ff);
+  --inventory-switch-shadow: 0 4px 12px rgba(30, 110, 190, 0.22);
+  --inventory-nav-item-bg: rgba(30, 110, 190, 0.1);
+  --inventory-nav-item-color: var(--inventory-text);
+  --inventory-nav-item-active-color: #0a1f3a;
+  --inventory-focus-border: rgba(46, 140, 255, 0.75);
+  --inventory-focus-ring: rgba(46, 140, 255, 0.2);
+  --inventory-neutral-button-border: rgba(30, 110, 190, 0.24);
+  --inventory-neutral-button-bg: rgba(30, 110, 190, 0.12);
+  --inventory-neutral-button-hover-bg: rgba(30, 110, 190, 0.2);
+  --inventory-neutral-button-hover-border: rgba(30, 110, 190, 0.3);
+  --inventory-popover-border: rgba(30, 110, 190, 0.2);
+  --inventory-popover-shadow: 0 18px 36px rgba(18, 43, 72, 0.16);
+  --inventory-popover-hover: rgba(30, 110, 190, 0.16);
+  --inventory-table-border: rgba(30, 110, 190, 0.18);
+  --inventory-table-stripe: rgba(30, 110, 190, 0.08);
+  --inventory-secondary-bg: rgba(247, 251, 255, 0.95);
+  --inventory-highlight-bg: rgba(30, 110, 190, 0.12);
+  --inventory-danger-bg: rgba(214, 92, 92, 0.14);
+  --inventory-danger-border: rgba(214, 92, 92, 0.32);
+  --inventory-danger-text: #a63f3f;
+  --inventory-pagination-bg: rgba(30, 110, 190, 0.18);
+  --inventory-pagination-hover: rgba(30, 110, 190, 0.28);
+  --inventory-footer-color: rgba(18, 44, 72, 0.7);
+}
+
+body[data-theme="dark"] {
   --inventory-bg: rgba(8, 26, 45, 0.72);
   --inventory-panel: rgba(10, 35, 60, 0.88);
   --inventory-border: rgba(70, 120, 170, 0.35);
@@ -12,9 +61,39 @@
   --inventory-input-bg: rgba(9, 33, 56, 0.88);
   --inventory-input-border: rgba(72, 125, 184, 0.45);
   --inventory-chip: rgba(38, 196, 255, 0.15);
-}
-
-body[data-theme="dark"] {
+  --inventory-header-bg: rgba(6, 22, 40, 0.88);
+  --inventory-header-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+  --inventory-header-sheen: linear-gradient(
+    120deg,
+    rgba(109, 120, 255, 0.12),
+    rgba(42, 209, 255, 0.1)
+  );
+  --inventory-switch-bg: rgba(120, 160, 220, 0.28);
+  --inventory-switch-border: rgba(90, 130, 190, 0.48);
+  --inventory-switch-knob: linear-gradient(135deg, #ffffff, #cfe4ff);
+  --inventory-switch-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  --inventory-nav-item-bg: rgba(110, 140, 200, 0.12);
+  --inventory-nav-item-color: var(--inventory-muted);
+  --inventory-nav-item-active-color: #041325;
+  --inventory-focus-border: rgba(90, 170, 255, 0.8);
+  --inventory-focus-ring: rgba(90, 170, 255, 0.18);
+  --inventory-neutral-button-border: rgba(110, 180, 255, 0.4);
+  --inventory-neutral-button-bg: rgba(90, 150, 220, 0.24);
+  --inventory-neutral-button-hover-bg: rgba(110, 180, 255, 0.36);
+  --inventory-neutral-button-hover-border: rgba(140, 210, 255, 0.5);
+  --inventory-popover-border: rgba(110, 180, 255, 0.2);
+  --inventory-popover-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  --inventory-popover-hover: rgba(110, 180, 255, 0.18);
+  --inventory-table-border: rgba(110, 170, 255, 0.12);
+  --inventory-table-stripe: rgba(110, 170, 255, 0.08);
+  --inventory-secondary-bg: rgba(7, 24, 40, 0.78);
+  --inventory-highlight-bg: rgba(110, 170, 255, 0.14);
+  --inventory-danger-bg: rgba(255, 107, 107, 0.18);
+  --inventory-danger-border: rgba(255, 107, 107, 0.4);
+  --inventory-danger-text: #ffb6b6;
+  --inventory-pagination-bg: rgba(110, 170, 255, 0.28);
+  --inventory-pagination-hover: rgba(110, 170, 255, 0.38);
+  --inventory-footer-color: rgba(178, 198, 224, 0.85);
   color-scheme: dark;
 }
 
@@ -24,6 +103,11 @@ body.servigenman-login.inventory-layout {
   min-height: 100vh;
   padding: 0;
   overflow-y: auto;
+  color-scheme: light;
+}
+
+body.servigenman-login.inventory-layout[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 .inventory-page {
@@ -53,9 +137,9 @@ body.servigenman-login.inventory-layout {
   position: sticky;
   top: 0;
   z-index: 30;
-  background: rgba(6, 22, 40, 0.88);
+  background: var(--inventory-header-bg);
   border-bottom: 1px solid var(--inventory-border);
-  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--inventory-header-shadow);
   backdrop-filter: blur(18px);
 }
 
@@ -63,7 +147,7 @@ body.servigenman-login.inventory-layout {
   content: "";
   position: absolute;
   inset: 0;
-  background: linear-gradient(120deg, rgba(109, 120, 255, 0.12), rgba(42, 209, 255, 0.1));
+  background: var(--inventory-header-sheen);
   opacity: 0.4;
   pointer-events: none;
 }
@@ -106,8 +190,8 @@ body.servigenman-login.inventory-layout {
   width: 44px;
   height: 24px;
   border-radius: 20px;
-  background: rgba(120, 160, 220, 0.28);
-  border: 1px solid rgba(90, 130, 190, 0.48);
+  background: var(--inventory-switch-bg);
+  border: 1px solid var(--inventory-switch-border);
   display: inline-flex;
   align-items: center;
   padding: 3px;
@@ -121,8 +205,8 @@ body.servigenman-login.inventory-layout {
   width: 18px;
   height: 18px;
   border-radius: 50%;
-  background: linear-gradient(135deg, #ffffff, #cfe4ff);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  background: var(--inventory-switch-knob);
+  box-shadow: var(--inventory-switch-shadow);
   transform: translateX(0px);
   transition: transform 0.2s ease;
 }
@@ -141,19 +225,19 @@ nav ul {
 }
 
 nav a {
-  color: var(--inventory-muted);
+  color: var(--inventory-nav-item-color);
   text-decoration: none;
   font-weight: 600;
   padding: 8px 14px;
   border-radius: 999px;
   transition: background 0.2s ease, color 0.2s ease;
-  background: rgba(110, 140, 200, 0.12);
+  background: var(--inventory-nav-item-bg);
 }
 
 nav a[aria-current="page"],
 nav a:hover {
   background: var(--inventory-accent);
-  color: #041325;
+  color: var(--inventory-nav-item-active-color);
 }
 
 .inventory-main {
@@ -217,8 +301,8 @@ nav a:hover {
 
 .form-grid input:focus {
   outline: none;
-  border-color: rgba(90, 170, 255, 0.8);
-  box-shadow: 0 0 0 3px rgba(90, 170, 255, 0.18);
+  border-color: var(--inventory-focus-border);
+  box-shadow: 0 0 0 3px var(--inventory-focus-ring);
 }
 
 .boton-agregar {
@@ -268,8 +352,8 @@ select.filtro-input {
 
 .boton-limpiar,
 .boton-exportar {
-  border: 1px solid rgba(110, 180, 255, 0.4);
-  background: rgba(90, 150, 220, 0.24);
+  border: 1px solid var(--inventory-neutral-button-border);
+  background: var(--inventory-neutral-button-bg);
   color: var(--inventory-text);
   border-radius: 14px;
   padding: 12px 16px;
@@ -280,8 +364,8 @@ select.filtro-input {
 
 .boton-limpiar:hover,
 .boton-exportar:hover {
-  background: rgba(110, 180, 255, 0.36);
-  border-color: rgba(140, 210, 255, 0.5);
+  background: var(--inventory-neutral-button-hover-bg);
+  border-color: var(--inventory-neutral-button-hover-border);
 }
 
 .autocomplete-container {
@@ -294,9 +378,9 @@ select.filtro-input {
   left: 0;
   right: 0;
   background: var(--inventory-surface);
-  border: 1px solid rgba(110, 180, 255, 0.2);
+  border: 1px solid var(--inventory-popover-border);
   border-radius: 12px;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--inventory-popover-shadow);
   max-height: 260px;
   overflow-y: auto;
   display: none;
@@ -314,7 +398,7 @@ select.filtro-input {
 }
 
 .sugerencia-item:hover {
-  background: rgba(110, 180, 255, 0.18);
+  background: var(--inventory-popover-hover);
 }
 
 .exportar-dropdown {
@@ -327,9 +411,9 @@ select.filtro-input {
   right: 0;
   min-width: 220px;
   background: var(--inventory-surface);
-  border: 1px solid rgba(110, 180, 255, 0.2);
+  border: 1px solid var(--inventory-popover-border);
   border-radius: 14px;
-  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.45);
+  box-shadow: var(--inventory-popover-shadow);
   padding: 12px;
   display: none;
   z-index: 4;
@@ -351,7 +435,7 @@ select.filtro-input {
 
 .submenu-btn {
   border: none;
-  background: rgba(90, 150, 220, 0.25);
+  background: var(--inventory-neutral-button-bg);
   color: var(--inventory-text);
   border-radius: 12px;
   padding: 10px 12px;
@@ -362,7 +446,7 @@ select.filtro-input {
 }
 
 .submenu-btn:hover {
-  background: rgba(110, 180, 255, 0.38);
+  background: var(--inventory-neutral-button-hover-bg);
 }
 
 .submenu-content {
@@ -385,14 +469,14 @@ select.filtro-input {
 }
 
 .submenu-content a:hover {
-  background: rgba(110, 180, 255, 0.18);
+  background: var(--inventory-popover-hover);
 }
 
 .tabla-scroll {
   border: 1px solid var(--inventory-border);
   border-radius: 18px;
   overflow: hidden;
-  background: rgba(7, 24, 40, 0.78);
+  background: var(--inventory-secondary-bg);
 }
 
 #tablaRecursos {
@@ -402,7 +486,7 @@ select.filtro-input {
 }
 
 #tablaRecursos thead {
-  background: rgba(110, 170, 255, 0.14);
+  background: var(--inventory-highlight-bg);
   text-transform: uppercase;
   font-size: 12px;
   letter-spacing: 0.6px;
@@ -412,11 +496,11 @@ select.filtro-input {
 #tablaRecursos td {
   padding: 14px 16px;
   text-align: left;
-  border-bottom: 1px solid rgba(110, 170, 255, 0.12);
+  border-bottom: 1px solid var(--inventory-table-border);
 }
 
 #tablaRecursos tbody tr:hover {
-  background: rgba(110, 170, 255, 0.08);
+  background: var(--inventory-table-stripe);
 }
 
 .thumb {
@@ -424,8 +508,8 @@ select.filtro-input {
   height: 48px;
   object-fit: cover;
   border-radius: 12px;
-  background: rgba(110, 170, 255, 0.12);
-  border: 1px solid rgba(110, 170, 255, 0.18);
+  background: var(--inventory-table-stripe);
+  border: 1px solid var(--inventory-table-border);
 }
 
 .tabla-acciones {
@@ -453,9 +537,9 @@ select.filtro-input {
 
 .boton-eliminar,
 .boton-cancelar {
-  background: rgba(255, 107, 107, 0.18);
-  color: #ffb6b6;
-  border: 1px solid rgba(255, 107, 107, 0.4);
+  background: var(--inventory-danger-bg);
+  color: var(--inventory-danger-text);
+  border: 1px solid var(--inventory-danger-border);
 }
 
 .boton-editar:hover,
@@ -477,7 +561,7 @@ select.filtro-input {
   padding: 10px 16px;
   border-radius: 12px;
   border: none;
-  background: rgba(110, 170, 255, 0.28);
+  background: var(--inventory-pagination-bg);
   color: var(--inventory-text);
   font-weight: 600;
   cursor: pointer;
@@ -490,12 +574,12 @@ select.filtro-input {
 }
 
 .paginacion button:not(:disabled):hover {
-  background: rgba(110, 170, 255, 0.38);
+  background: var(--inventory-pagination-hover);
 }
 
 .inventory-footer {
   text-align: center;
-  color: var(--inventory-muted);
+  color: var(--inventory-footer-color);
   font-size: 13px;
   padding-bottom: 16px;
 }

--- a/frontend/src/app/presupuesto/styles.css
+++ b/frontend/src/app/presupuesto/styles.css
@@ -1,4 +1,19 @@
 :root {
+  --budget-surface: rgba(255, 255, 255, 0.95);
+  --budget-border: rgba(32, 110, 190, 0.2);
+  --budget-shadow: 0 20px 48px rgba(18, 43, 72, 0.16);
+  --budget-muted: #566b88;
+  --budget-text: #10243f;
+  --budget-panel: rgba(245, 250, 255, 0.94);
+  --budget-panel-border: rgba(32, 110, 190, 0.2);
+  --budget-chip: rgba(46, 120, 255, 0.14);
+  --budget-card-shadow: 0 12px 36px rgba(18, 43, 72, 0.16);
+  --budget-panel-shadow: 0 16px 40px rgba(18, 43, 72, 0.18);
+  --budget-table-head: rgba(46, 120, 255, 0.12);
+  --budget-footer-color: rgba(18, 44, 72, 0.7);
+}
+
+body[data-theme="dark"] {
   --budget-surface: rgba(12, 34, 58, 0.92);
   --budget-border: rgba(82, 150, 220, 0.32);
   --budget-shadow: 0 28px 60px rgba(0, 0, 0, 0.55);
@@ -7,9 +22,10 @@
   --budget-panel: rgba(10, 29, 52, 0.88);
   --budget-panel-border: rgba(90, 150, 220, 0.35);
   --budget-chip: rgba(109, 120, 255, 0.18);
-}
-
-body[data-theme="dark"] {
+  --budget-card-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+  --budget-panel-shadow: 0 16px 44px rgba(0, 0, 0, 0.4);
+  --budget-table-head: rgba(109, 120, 255, 0.12);
+  --budget-footer-color: var(--budget-muted);
   color-scheme: dark;
 }
 
@@ -74,7 +90,7 @@ body[data-theme="dark"] {
   border: 1px solid var(--budget-panel-border);
   border-radius: 18px;
   padding: 20px 22px;
-  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.35);
+  box-shadow: var(--budget-card-shadow);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -111,7 +127,7 @@ body[data-theme="dark"] {
   border: 1px solid var(--budget-panel-border);
   border-radius: 22px;
   padding: 26px;
-  box-shadow: 0 16px 44px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--budget-panel-shadow);
   min-height: 320px;
   display: flex;
   flex-direction: column;
@@ -159,7 +175,7 @@ body[data-theme="dark"] {
 }
 
 .table-sm thead th {
-  background: rgba(109, 120, 255, 0.12);
+  background: var(--budget-table-head);
   color: var(--budget-text);
 }
 
@@ -180,7 +196,7 @@ body[data-theme="dark"] {
 
 .budget-footer {
   text-align: center;
-  color: var(--budget-muted);
+  color: var(--budget-footer-color);
   font-size: 0.95rem;
 }
 


### PR DESCRIPTION
## Summary
- add a light theme palette to the home, inventory, categories and budget modules while keeping the dark theme toggle working
- reuse the stored theme preference across pages by updating shared CSS variables and color-scheme hints
- replace the login logo asset with the new Servigenman illustration used in splash and branding spots

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dc017c1fd483268bcde1ced31b1a72