### PR TITLE
Fix API rewrite to point to Django backend

### DIFF
--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -3,7 +3,10 @@
 const nextConfig: NextConfig = {
   async rewrites() {
     return [
-      { source: '/api/:path*', destination: 'http://localhost:8000/:path*' },
+      {
+        source: '/api/:path*',
+        destination: 'http://localhost:8000/api/:path*',
+      },
     ]
   },
 }


### PR DESCRIPTION
## Summary
- adjust the Next.js rewrite so `/api/*` requests are forwarded to the Django backend under `/api/`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5d56631248326a28b85a7ad4c32e7