### PR TITLE
Enforce fallback login credentials

### DIFF
--- a/frontend/src/app/(auth)/login/constants.ts
+++ b/frontend/src/app/(auth)/login/constants.ts
@@ -1,1 +1,12 @@
 export const LOGO_SRC = "/logo-servigenman.svg";
+
+export const FALLBACK_CREDENTIALS = {
+  username: "jona",
+  password: "200328",
+  user: {
+    username: "jona",
+    first_name: "Jonathan",
+    last_name: "Morales",
+    email: "jonathan.morales@servigenman.cl",
+  },
+} as const;

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { AnimatedBackground } from "./components/AnimatedBackground";
 import { LoginCard } from "./components/LoginCard";
 import { SplashOverlay } from "./components/SplashOverlay";
+import { FALLBACK_CREDENTIALS } from "./constants";
 import { useAnimatedRays } from "./hooks/useAnimatedRays";
 import { useBodyClass } from "./hooks/useBodyClass";
 import { useSplashSequence } from "./hooks/useSplashSequence";
@@ -67,14 +68,20 @@ export default function LoginPage() {
     setErrorMessage(null);
 
     if (!shouldUseApiLogin) {
+      const matchesUsername =
+        sanitizedUsername.toLowerCase() ===
+        FALLBACK_CREDENTIALS.username.toLowerCase();
+      const matchesPassword = password === FALLBACK_CREDENTIALS.password;
+
+      if (!matchesUsername || !matchesPassword) {
+        setErrorMessage("Usuario o contraseña incorrectos.");
+        setSuccess(null);
+        return;
+      }
+
       setSuccess({
         message: "Inicio de sesión exitoso.",
-        user: {
-          username: sanitizedUsername,
-          first_name: "",
-          last_name: "",
-          email: "",
-        },
+        user: FALLBACK_CREDENTIALS.user,
       });
       return;
     }


### PR DESCRIPTION
## Summary
- add a fallback credential definition for the local login flow
- require the expected username and password before treating the login as successful
- surface an error message when the fallback credentials do not match

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e7c1aa3efc832683980ab56312085d